### PR TITLE
Fix strict replay applicability checks

### DIFF
--- a/manual-tui-testing/scripts/03_run_json_mode.ps1
+++ b/manual-tui-testing/scripts/03_run_json_mode.ps1
@@ -1,3 +1,11 @@
+<#
+.SYNOPSIS
+Runs a non-TUI JSON-mode LocalAgent smoke test against the manual fixture.
+
+.EXAMPLE
+pwsh ./manual-tui-testing/scripts/03_run_json_mode.ps1 -Provider mock -Model mock-model -Prompt "Use glob with pattern 'src/**/*.rs' and then grep TODO."
+#>
+
 param(
     [Parameter(Mandatory = $true)]
     [ValidateSet("lmstudio", "ollama", "llamacpp", "mock")]

--- a/src/repro.rs
+++ b/src/repro.rs
@@ -325,28 +325,7 @@ pub fn verify_run_record(record: &RunRecord, strict: bool) -> anyhow::Result<Rep
         ));
     }
 
-    let hooks_path = Path::new(&record.cli.hooks_config_path);
-    if hooks_path.exists() {
-        let bytes = std::fs::read(hooks_path)
-            .with_context(|| format!("failed reading hooks config {}", hooks_path.display()))?;
-        let actual = sha256_hex(&bytes);
-        checks.push(ReplayVerifyCheck {
-            name: "hooks_config_hash_hex".to_string(),
-            expected: record
-                .hooks_config_hash_hex
-                .clone()
-                .unwrap_or_else(|| "-".to_string()),
-            ok: record.hooks_config_hash_hex.as_deref() == Some(actual.as_str()),
-            actual,
-            severity: "warn".to_string(),
-            note: None,
-        });
-    } else {
-        checks.push(unavailable_check(
-            "hooks_config_hash_hex",
-            "hooks config path unavailable",
-        ));
-    }
+    checks.push(verify_hooks_config_hash(record)?);
 
     let builtin = builtin_tools_enabled(true, true);
     let mut actual_schema_map = crate::store::tool_schema_hash_hex_map(&builtin);
@@ -496,8 +475,68 @@ fn unavailable_check(name: &str, note: &str) -> ReplayVerifyCheck {
     }
 }
 
+fn verify_hooks_config_hash(record: &RunRecord) -> anyhow::Result<ReplayVerifyCheck> {
+    if record.cli.hooks_mode == "off" {
+        return Ok(ReplayVerifyCheck {
+            name: "hooks_config_hash_hex".to_string(),
+            expected: record
+                .hooks_config_hash_hex
+                .clone()
+                .unwrap_or_else(|| "-".to_string()),
+            actual: "not_applicable".to_string(),
+            ok: record.hooks_config_hash_hex.is_none(),
+            severity: "warn".to_string(),
+            note: Some("hooks disabled for this run".to_string()),
+        });
+    }
+
+    let hooks_path = Path::new(&record.cli.hooks_config_path);
+    if hooks_path.exists() {
+        let bytes = std::fs::read(hooks_path)
+            .with_context(|| format!("failed reading hooks config {}", hooks_path.display()))?;
+        let actual = sha256_hex(&bytes);
+        Ok(ReplayVerifyCheck {
+            name: "hooks_config_hash_hex".to_string(),
+            expected: record
+                .hooks_config_hash_hex
+                .clone()
+                .unwrap_or_else(|| "-".to_string()),
+            ok: record.hooks_config_hash_hex.as_deref() == Some(actual.as_str()),
+            actual,
+            severity: "warn".to_string(),
+            note: None,
+        })
+    } else {
+        Ok(unavailable_check(
+            "hooks_config_hash_hex",
+            "hooks config path unavailable",
+        ))
+    }
+}
+
+fn has_mcp_runtime_surface(record: &RunRecord) -> bool {
+    !record.cli.mcp_servers.is_empty()
+        || !record.cli.mcp_tool_snapshot.is_empty()
+        || record.cli.max_mcp_calls > 0
+        || record
+            .tool_calls
+            .iter()
+            .any(|tc| tc.name.starts_with("mcp."))
+        || !record.mcp_runtime_trace.is_empty()
+}
+
 fn verify_mcp_runtime_trace_continuity(record: &RunRecord) -> ReplayVerifyCheck {
     if record.mcp_runtime_trace.is_empty() {
+        if !has_mcp_runtime_surface(record) {
+            return ReplayVerifyCheck {
+                name: "mcp_runtime_trace_continuity".to_string(),
+                expected: "continuous transitions with terminal lifecycle".to_string(),
+                actual: "not_applicable".to_string(),
+                ok: true,
+                severity: "warn".to_string(),
+                note: Some("no MCP runtime configured for this run".to_string()),
+            };
+        }
         return ReplayVerifyCheck {
             name: "mcp_runtime_trace_continuity".to_string(),
             expected: "continuous transitions with terminal lifecycle".to_string(),
@@ -657,17 +696,345 @@ pub fn stable_workdir_string(path: &Path) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        build_repro_record, env_fingerprint, looks_secret_key, repro_hash_hex, ReproBuildInput,
-        ReproEnvMode, ReproMode,
+        build_repro_record, env_fingerprint, looks_secret_key, repro_hash_hex,
+        verify_hooks_config_hash, verify_mcp_runtime_trace_continuity, verify_run_record,
+        ReproBuildInput, ReproEnvMode, ReproMode,
     };
-    use crate::store::ToolCatalogEntry;
-    use crate::types::SideEffects;
+    use crate::agent::McpRuntimeTraceEntry;
+    use crate::store::{
+        ConfigFingerprintV1, RunCliConfig, RunMetadata, RunRecord, RunResolvedPaths,
+        ToolCatalogEntry,
+    };
+    use crate::types::{SideEffects, ToolCall};
     use std::collections::BTreeMap;
+    use std::path::Path;
     use std::sync::{Mutex, OnceLock};
+    use tempfile::tempdir;
 
     fn env_test_lock() -> &'static Mutex<()> {
         static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
         LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    fn minimal_cli_config(hooks_path: &Path, mcp_config_path: &Path) -> RunCliConfig {
+        RunCliConfig {
+            mode: "single".to_string(),
+            agent_mode: "plan".to_string(),
+            output_mode: "json".to_string(),
+            provider: "mock".to_string(),
+            base_url: "mock://local".to_string(),
+            model: "mock-model".to_string(),
+            temperature: None,
+            top_p: None,
+            max_tokens: None,
+            seed: None,
+            planner_model: Some("mock-model".to_string()),
+            worker_model: Some("mock-model".to_string()),
+            planner_max_steps: Some(2),
+            planner_output: Some("json".to_string()),
+            planner_strict: Some(true),
+            enforce_plan_tools: "off".to_string(),
+            mcp_pin_enforcement: "hard".to_string(),
+            trust_mode: "on".to_string(),
+            allow_shell: false,
+            allow_write: false,
+            enable_write_tools: false,
+            exec_target: "host".to_string(),
+            docker_image: None,
+            docker_workdir: None,
+            docker_network: None,
+            docker_user: None,
+            docker_config_summary: None,
+            max_tool_output_bytes: 200_000,
+            max_read_bytes: 200_000,
+            max_wall_time_ms: 0,
+            max_total_tool_calls: 0,
+            max_mcp_calls: 0,
+            max_filesystem_read_calls: 0,
+            max_filesystem_write_calls: 0,
+            max_shell_calls: 0,
+            max_network_calls: 0,
+            max_browser_calls: 0,
+            tool_exec_timeout_ms: 30_000,
+            post_write_verify_timeout_ms: 5_000,
+            approval_mode: "interrupt".to_string(),
+            auto_approve_scope: "run".to_string(),
+            approval_key: "v1".to_string(),
+            unsafe_mode: false,
+            no_limits: false,
+            unsafe_bypass_allow_flags: false,
+            stream: false,
+            events_path: None,
+            max_context_chars: 0,
+            compaction_mode: "off".to_string(),
+            compaction_keep_last: 20,
+            tool_result_persist: "digest".to_string(),
+            hooks_mode: "off".to_string(),
+            caps_mode: "off".to_string(),
+            hooks_config_path: hooks_path.display().to_string(),
+            hooks_strict: false,
+            hooks_timeout_ms: 2_000,
+            hooks_max_stdout_bytes: 200_000,
+            tool_args_strict: "on".to_string(),
+            taint: "off".to_string(),
+            taint_mode: "propagate".to_string(),
+            taint_digest_bytes: 4096,
+            repro: "off".to_string(),
+            repro_env: "safe".to_string(),
+            repro_out: None,
+            use_session_settings: false,
+            resolved_settings_source: BTreeMap::new(),
+            tui_enabled: false,
+            tui_refresh_ms: 50,
+            tui_max_log_lines: 200,
+            http_max_retries: 2,
+            http_timeout_ms: 120_000,
+            http_connect_timeout_ms: 2_000,
+            http_stream_idle_timeout_ms: 30_000,
+            http_max_response_bytes: 10_000_000,
+            http_max_line_bytes: 200_000,
+            tool_catalog: vec![ToolCatalogEntry {
+                name: "read_file".to_string(),
+                side_effects: SideEffects::FilesystemRead,
+            }],
+            mcp_tool_snapshot: Vec::new(),
+            mcp_tool_catalog_hash_hex: None,
+            mcp_servers: Vec::new(),
+            mcp_config_path: Some(mcp_config_path.display().to_string()),
+            policy_version: Some(2),
+            includes_resolved: Vec::new(),
+            mcp_allowlist: None,
+            instructions_config_path: None,
+            instructions_config_hash_hex: None,
+            instruction_model_profile: None,
+            instruction_task_profile: None,
+            instruction_task_profile_task_kind: None,
+            instruction_message_count: 0,
+            project_guidance_hash_hex: None,
+            project_guidance_sources: Vec::new(),
+            project_guidance_truncated: false,
+            project_guidance_bytes_loaded: 0,
+            project_guidance_bytes_kept: 0,
+            repo_map_hash_hex: None,
+            repo_map_format: None,
+            repo_map_truncated: false,
+            repo_map_truncated_reason: None,
+            repo_map_bytes_scanned: 0,
+            repo_map_bytes_kept: 0,
+            repo_map_file_count_included: 0,
+            repo_map_injected: false,
+            repo_map_likely_target_files_count: 0,
+            lsp_context_provider: None,
+            lsp_context_schema_version: None,
+            lsp_context_truncated: false,
+            lsp_context_truncation_reason: None,
+            lsp_context_bytes_kept: 0,
+            lsp_context_diagnostics_included: 0,
+            lsp_context_symbol_query: None,
+            lsp_context_symbols_included: 0,
+            lsp_context_definitions_included: 0,
+            lsp_context_references_included: 0,
+            lsp_context_injected: false,
+            lsp_context_likely_target_files_count: 0,
+            active_profile: None,
+            profile_source: None,
+            profile_hash_hex: None,
+            activated_packs: Vec::new(),
+        }
+    }
+
+    fn minimal_config_fingerprint(
+        state_dir: &Path,
+        policy_path: &Path,
+        hooks_path: &Path,
+        mcp_config_path: &Path,
+    ) -> ConfigFingerprintV1 {
+        ConfigFingerprintV1 {
+            schema_version: "openagent.confighash.v1".to_string(),
+            mode: "single".to_string(),
+            agent_mode: "plan".to_string(),
+            provider: "mock".to_string(),
+            base_url: "mock://local".to_string(),
+            model: "mock-model".to_string(),
+            planner_model: "mock-model".to_string(),
+            worker_model: "mock-model".to_string(),
+            planner_max_steps: 2,
+            planner_output: "json".to_string(),
+            planner_strict: true,
+            enforce_plan_tools: "off".to_string(),
+            mcp_pin_enforcement: "hard".to_string(),
+            trust_mode: "on".to_string(),
+            state_dir: state_dir.display().to_string(),
+            policy_path: policy_path.display().to_string(),
+            approvals_path: state_dir.join("approvals.json").display().to_string(),
+            audit_path: state_dir.join("audit.jsonl").display().to_string(),
+            allow_shell: false,
+            allow_write: false,
+            enable_write_tools: false,
+            exec_target: "host".to_string(),
+            docker_image: String::new(),
+            docker_workdir: String::new(),
+            docker_network: String::new(),
+            docker_user: String::new(),
+            max_steps: 20,
+            max_tool_output_bytes: 200_000,
+            max_read_bytes: 200_000,
+            max_wall_time_ms: 0,
+            max_total_tool_calls: 0,
+            max_mcp_calls: 0,
+            max_filesystem_read_calls: 0,
+            max_filesystem_write_calls: 0,
+            max_shell_calls: 0,
+            max_network_calls: 0,
+            max_browser_calls: 0,
+            tool_exec_timeout_ms: 30_000,
+            post_write_verify_timeout_ms: 5_000,
+            session_name: String::new(),
+            no_session: true,
+            max_session_messages: 40,
+            approval_mode: "interrupt".to_string(),
+            auto_approve_scope: "run".to_string(),
+            approval_key: "v1".to_string(),
+            unsafe_mode: false,
+            no_limits: false,
+            unsafe_bypass_allow_flags: false,
+            stream: false,
+            events_path: String::new(),
+            max_context_chars: 0,
+            compaction_mode: "off".to_string(),
+            compaction_keep_last: 20,
+            tool_result_persist: "digest".to_string(),
+            hooks_mode: "off".to_string(),
+            caps_mode: "off".to_string(),
+            hooks_config_path: hooks_path.display().to_string(),
+            hooks_strict: false,
+            hooks_timeout_ms: 2_000,
+            hooks_max_stdout_bytes: 200_000,
+            tool_args_strict: "on".to_string(),
+            taint: "off".to_string(),
+            taint_mode: "propagate".to_string(),
+            taint_digest_bytes: 4096,
+            repro: "off".to_string(),
+            repro_env: "safe".to_string(),
+            repro_out: String::new(),
+            use_session_settings: false,
+            resolved_settings_source: BTreeMap::new(),
+            tui_enabled: false,
+            tui_refresh_ms: 50,
+            tui_max_log_lines: 200,
+            http_max_retries: 2,
+            http_timeout_ms: 120_000,
+            http_connect_timeout_ms: 2_000,
+            http_stream_idle_timeout_ms: 30_000,
+            http_max_response_bytes: 10_000_000,
+            http_max_line_bytes: 200_000,
+            tool_catalog_names: vec!["read_file".to_string()],
+            mcp_tool_catalog_hash_hex: String::new(),
+            mcp_servers: Vec::new(),
+            mcp_config_path: mcp_config_path.display().to_string(),
+            policy_version: Some(2),
+            includes_resolved: Vec::new(),
+            mcp_allowlist: None,
+            instructions_config_path: String::new(),
+            instructions_config_hash_hex: String::new(),
+            instruction_model_profile: String::new(),
+            instruction_task_profile: String::new(),
+            instruction_task_profile_task_kind: String::new(),
+            instruction_message_count: 0,
+            lsp_context_provider: String::new(),
+            lsp_context_schema_version: String::new(),
+            lsp_context_truncated: false,
+            lsp_context_truncation_reason: String::new(),
+            lsp_context_bytes_kept: 0,
+            lsp_context_diagnostics_included: 0,
+            lsp_context_symbol_query: String::new(),
+            lsp_context_symbols_included: 0,
+            lsp_context_definitions_included: 0,
+            lsp_context_references_included: 0,
+            lsp_context_injected: false,
+            repo_map_likely_target_files_count: 0,
+            lsp_context_likely_target_files_count: 0,
+        }
+    }
+
+    fn minimal_run_record(state_dir: &Path) -> RunRecord {
+        let policy_path = state_dir.join("policy.yaml");
+        let hooks_path = state_dir.join("hooks.yaml");
+        let mcp_config_path = state_dir.join("mcp_servers.json");
+        std::fs::write(&policy_path, b"version: 2\ndefault: deny\n").expect("policy");
+        std::fs::write(&hooks_path, b"version: 1\nhooks: []\n").expect("hooks");
+        std::fs::write(
+            &mcp_config_path,
+            b"{\"schema_version\":\"openagent.mcp_servers.v1\",\"servers\":{}}\n",
+        )
+        .expect("mcp config");
+        let policy_hash_hex =
+            crate::store::sha256_hex(&std::fs::read(&policy_path).expect("policy bytes"));
+        let config_fingerprint =
+            minimal_config_fingerprint(state_dir, &policy_path, &hooks_path, &mcp_config_path);
+        let config_hash_hex =
+            crate::store::config_hash_hex(&config_fingerprint).expect("config hash");
+        RunRecord {
+            metadata: RunMetadata {
+                run_id: "run-1".to_string(),
+                started_at: "2026-01-01T00:00:00Z".to_string(),
+                finished_at: "2026-01-01T00:00:01Z".to_string(),
+                exit_reason: "ok".to_string(),
+            },
+            mode: "single".to_string(),
+            planner: None,
+            worker: None,
+            cli: minimal_cli_config(&hooks_path, &mcp_config_path),
+            resolved_paths: RunResolvedPaths {
+                state_dir: state_dir.display().to_string(),
+                policy_path: policy_path.display().to_string(),
+                approvals_path: state_dir.join("approvals.json").display().to_string(),
+                audit_path: state_dir.join("audit.jsonl").display().to_string(),
+            },
+            policy_source: "file".to_string(),
+            policy_hash_hex: Some(policy_hash_hex),
+            policy_version: Some(2),
+            includes_resolved: Vec::new(),
+            mcp_allowlist: None,
+            config_hash_hex,
+            config_fingerprint: Some(config_fingerprint),
+            task_contract: None,
+            task_contract_provenance: None,
+            run_checkpoint: None,
+            final_checkpoint: None,
+            execution_tier: None,
+            interrupt_history: Vec::new(),
+            phase_summary: Vec::new(),
+            completion_decisions: Vec::new(),
+            tool_schema_hash_hex_map: BTreeMap::new(),
+            hooks_config_hash_hex: None,
+            transcript: Vec::new(),
+            tool_calls: Vec::new(),
+            tool_decisions: Vec::new(),
+            tool_facts: Vec::new(),
+            tool_fact_envelopes: Vec::new(),
+            compaction: None,
+            hook_report: Vec::new(),
+            tool_catalog: Vec::new(),
+            mcp_runtime_trace: Vec::new(),
+            tool_reliability: Default::default(),
+            mcp_pin_snapshot: None,
+            taint: None,
+            repro: None,
+            final_output: "ok".to_string(),
+            error: None,
+        }
+    }
+
+    fn check<'a>(
+        report: &'a super::ReplayVerifyReport,
+        name: &str,
+    ) -> &'a super::ReplayVerifyCheck {
+        report
+            .checks
+            .iter()
+            .find(|c| c.name == name)
+            .expect("check exists")
     }
 
     #[test]
@@ -732,5 +1099,89 @@ mod tests {
         assert!(looks_secret_key("GITHUB_PAT"));
         assert!(looks_secret_key("SESSION_COOKIE"));
         assert!(!looks_secret_key("PATH"));
+    }
+
+    #[test]
+    fn strict_verify_allows_disabled_hooks_and_absent_mcp_runtime() {
+        let tmp = tempdir().expect("tempdir");
+        let record = minimal_run_record(tmp.path());
+
+        let report = verify_run_record(&record, true).expect("verify");
+
+        assert_eq!(report.status, "pass");
+        let hooks = check(&report, "hooks_config_hash_hex");
+        assert!(hooks.ok);
+        assert_eq!(hooks.actual, "not_applicable");
+        assert_eq!(hooks.note.as_deref(), Some("hooks disabled for this run"));
+        let mcp = check(&report, "mcp_runtime_trace_continuity");
+        assert!(mcp.ok);
+        assert_eq!(mcp.actual, "not_applicable");
+        assert_eq!(
+            mcp.note.as_deref(),
+            Some("no MCP runtime configured for this run")
+        );
+    }
+
+    #[test]
+    fn hooks_enabled_missing_or_mismatched_hash_still_fails() {
+        let tmp = tempdir().expect("tempdir");
+        let mut record = minimal_run_record(tmp.path());
+        record.cli.hooks_mode = "on".to_string();
+
+        let missing = verify_hooks_config_hash(&record).expect("verify hooks");
+        assert!(!missing.ok);
+        assert_eq!(missing.expected, "-");
+
+        record.hooks_config_hash_hex = Some("bad".to_string());
+        let mismatched = verify_hooks_config_hash(&record).expect("verify hooks");
+        assert!(!mismatched.ok);
+        assert_eq!(mismatched.expected, "bad");
+    }
+
+    #[test]
+    fn no_mcp_configured_empty_trace_is_not_applicable() {
+        let tmp = tempdir().expect("tempdir");
+        let record = minimal_run_record(tmp.path());
+
+        let mcp = verify_mcp_runtime_trace_continuity(&record);
+
+        assert!(mcp.ok);
+        assert_eq!(mcp.actual, "not_applicable");
+        assert_eq!(
+            mcp.note.as_deref(),
+            Some("no MCP runtime configured for this run")
+        );
+    }
+
+    #[test]
+    fn mcp_configured_or_bad_trace_still_fails_continuity() {
+        let tmp = tempdir().expect("tempdir");
+        let mut configured = minimal_run_record(tmp.path());
+        configured.cli.mcp_servers = vec!["stub".to_string()];
+        let missing_trace = verify_mcp_runtime_trace_continuity(&configured);
+        assert!(!missing_trace.ok);
+        assert_eq!(missing_trace.actual, "unavailable");
+
+        let mut bad_trace = minimal_run_record(tmp.path());
+        bad_trace.mcp_runtime_trace = vec![McpRuntimeTraceEntry {
+            step: 1,
+            lifecycle: "done".to_string(),
+            tool_call_id: Some("tc1".to_string()),
+            tool_name: Some("mcp.stub.echo".to_string()),
+            reason: None,
+            progress_ticks: None,
+            elapsed_ms: None,
+        }];
+        bad_trace.tool_calls = vec![ToolCall {
+            id: "tc1".to_string(),
+            name: "mcp.stub.echo".to_string(),
+            arguments: serde_json::json!({}),
+        }];
+
+        let continuity = verify_mcp_runtime_trace_continuity(&bad_trace);
+
+        assert!(!continuity.ok);
+        assert_eq!(continuity.actual, "tool_calls=0 violations=1");
+        assert_eq!(continuity.note.as_deref(), Some("sample=tc1:none->done"));
     }
 }


### PR DESCRIPTION
Fixes strict replay applicability handling so disabled hooks and absent MCP runtime are reported as not_applicable instead of failing warnings. Enabled/configured subsystems still fail on missing, mismatched, or malformed data. Also documents mandatory -Prompt usage for the JSON mode manual test script.