### PR TITLE
Add shell command timeout and cleanup

### DIFF
--- a/src/target.rs
+++ b/src/target.rs
@@ -608,6 +608,30 @@ impl ExecTarget for DockerTarget {
     }
 
     async fn exec_shell(&self, req: ShellReq) -> TargetResult {
+        // Timeout enforcement is not implemented for the docker target (killing
+        // the `docker run` client would not reliably stop the container). Rather
+        // than silently ignore a requested bound, reject it with a structured,
+        // classifiable error so the model/operator gets a clear signal instead
+        // of an unexpectedly unbounded command.
+        if req.timeout_ms > 0 {
+            return TargetResult {
+                ok: false,
+                content: json!({
+                    "error": "timeout_unsupported",
+                    "execution_target": "docker",
+                    "timeout_ms": req.timeout_ms,
+                    "hint": "timeout_ms is not supported on the docker execution target. Re-run on the host target, or omit timeout_ms."
+                })
+                .to_string(),
+                truncated: false,
+                bytes: None,
+                exit_code: None,
+                stderr_truncated: None,
+                stdout_truncated: None,
+                execution_target: ExecTargetKind::Docker,
+                docker: Some(self.meta.clone()),
+            };
+        }
         let args = req
             .args
             .iter()
@@ -1353,6 +1377,34 @@ mod tests {
                 "echo hi"
             ]
         );
+    }
+
+    #[tokio::test]
+    async fn docker_shell_rejects_timeout_with_structured_error() {
+        // The guard returns before any docker invocation, so this is
+        // deterministic without docker installed.
+        let t = DockerTarget::new(
+            "ubuntu:24.04".to_string(),
+            "/work".to_string(),
+            "none".to_string(),
+            None,
+        );
+        let out = t
+            .exec_shell(ShellReq {
+                workdir: PathBuf::from("."),
+                cmd: "echo".to_string(),
+                args: vec!["hi".to_string()],
+                cwd: None,
+                max_tool_output_bytes: 200_000,
+                timeout_ms: 500,
+            })
+            .await;
+        assert!(!out.ok, "timeout on docker target must be rejected");
+        let parsed: serde_json::Value =
+            serde_json::from_str(&out.content).expect("structured docker rejection is JSON");
+        assert_eq!(parsed["error"], serde_json::json!("timeout_unsupported"));
+        assert_eq!(parsed["execution_target"], serde_json::json!("docker"));
+        assert_eq!(parsed["timeout_ms"], serde_json::json!(500));
     }
 
     #[test]

--- a/src/target.rs
+++ b/src/target.rs
@@ -68,6 +68,11 @@ pub struct ShellReq {
     pub args: Vec<String>,
     pub cwd: Option<String>,
     pub max_tool_output_bytes: usize,
+    /// Wall-clock timeout for the command, in milliseconds. `0` means unbounded
+    /// (the historical default). The `u64` type makes negative values
+    /// unrepresentable. Timeout enforcement currently applies to the host
+    /// execution target only; the docker target ignores this field (follow-up).
+    pub timeout_ms: u64,
 }
 
 #[derive(Debug, Clone)]
@@ -144,34 +149,14 @@ impl ExecTarget for HostTarget {
                 None => req.workdir.clone(),
             };
         command.current_dir(cwd);
-        match command.output().await {
-            Ok(output) => {
-                let stdout_raw = String::from_utf8_lossy(&output.stdout).to_string();
-                let stderr_raw = String::from_utf8_lossy(&output.stderr).to_string();
-                let (stdout, stdout_truncated) =
-                    truncate_utf8_to_bytes(&stdout_raw, req.max_tool_output_bytes);
-                let (stderr, stderr_truncated) =
-                    truncate_utf8_to_bytes(&stderr_raw, req.max_tool_output_bytes);
-                TargetResult {
-                    ok: output.status.success(),
-                    content: json!({
-                        "status": output.status.code(),
-                        "stdout": stdout,
-                        "stderr": stderr,
-                        "stdout_truncated": stdout_truncated,
-                        "stderr_truncated": stderr_truncated,
-                        "max_tool_output_bytes": req.max_tool_output_bytes
-                    })
-                    .to_string(),
-                    truncated: stdout_truncated || stderr_truncated,
-                    bytes: Some((output.stdout.len() + output.stderr.len()) as u64),
-                    exit_code: output.status.code(),
-                    stderr_truncated: Some(stderr_truncated),
-                    stdout_truncated: Some(stdout_truncated),
-                    execution_target: ExecTargetKind::Host,
-                    docker: None,
-                }
-            }
+        match spawn_and_wait_managed(command, req.timeout_ms, None).await {
+            Ok(managed) => build_shell_target_result(
+                ExecTargetKind::Host,
+                None,
+                managed,
+                req.timeout_ms,
+                req.max_tool_output_bytes,
+            ),
             Err(e) => TargetResult::failed(
                 ExecTargetKind::Host,
                 format!("shell execution failed: {e}"),
@@ -1005,6 +990,181 @@ fn path_is_workdir_scoped(path: &str) -> bool {
     })
 }
 
+/// Captured result of a managed child process, including whether the wait was
+/// terminated by a timeout. On timeout, `status` is `None` and partial
+/// stdout/stderr captured before termination are still returned.
+struct ManagedOutput {
+    status: Option<std::process::ExitStatus>,
+    stdout: Vec<u8>,
+    stderr: Vec<u8>,
+    timed_out: bool,
+}
+
+/// Spawn `command` with piped stdout/stderr and `kill_on_drop(true)`, drain its
+/// output concurrently, and wait for it to exit.
+///
+/// When `timeout_ms == 0` the wait is unbounded (historical behavior). When
+/// `timeout_ms > 0` and the deadline elapses, the direct child is killed and
+/// reaped, and `ManagedOutput::timed_out` is set.
+///
+/// Limitation: this kills and reaps the *direct* child only. A child launched
+/// through a shell wrapper (e.g. `sh -c "..."` or `cmd /C "..."`) may leave
+/// grandchild processes running until they exit on their own. Robust
+/// process-tree termination (unix process groups / Windows job objects) is a
+/// follow-up.
+async fn spawn_and_wait_managed(
+    mut command: Command,
+    timeout_ms: u64,
+    stdin_bytes: Option<&[u8]>,
+) -> std::io::Result<ManagedOutput> {
+    use std::sync::{Arc, Mutex};
+    use tokio::io::AsyncReadExt;
+
+    command
+        .stdin(if stdin_bytes.is_some() {
+            Stdio::piped()
+        } else {
+            Stdio::null()
+        })
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+
+    let mut child = command.spawn()?;
+
+    if let Some(data) = stdin_bytes {
+        if let Some(mut stdin) = child.stdin.take() {
+            stdin.write_all(data).await?;
+            // `stdin` is dropped here, closing the pipe so the child sees EOF.
+        }
+    }
+
+    // Drain stdout/stderr into shared buffers via incremental reads. Shared
+    // buffers (rather than `read_to_end` returning the bytes) let the timeout
+    // path recover whatever was captured so far even when the drain task is
+    // still blocked on a pipe held open by a surviving grandchild process.
+    fn drain<R>(pipe: Option<R>) -> (Arc<Mutex<Vec<u8>>>, tokio::task::JoinHandle<()>)
+    where
+        R: tokio::io::AsyncRead + Unpin + Send + 'static,
+    {
+        let buf = Arc::new(Mutex::new(Vec::new()));
+        let sink = buf.clone();
+        let handle = tokio::spawn(async move {
+            if let Some(mut p) = pipe {
+                let mut chunk = [0u8; 8192];
+                loop {
+                    match p.read(&mut chunk).await {
+                        Ok(0) | Err(_) => break,
+                        Ok(n) => {
+                            if let Ok(mut guard) = sink.lock() {
+                                guard.extend_from_slice(&chunk[..n]);
+                            }
+                        }
+                    }
+                }
+            }
+        });
+        (buf, handle)
+    }
+
+    let (stdout_buf, stdout_task) = drain(child.stdout.take());
+    let (stderr_buf, stderr_task) = drain(child.stderr.take());
+    let stdout_abort = stdout_task.abort_handle();
+    let stderr_abort = stderr_task.abort_handle();
+
+    let (status, timed_out) = if timeout_ms == 0 {
+        (Some(child.wait().await?), false)
+    } else {
+        match tokio::time::timeout(std::time::Duration::from_millis(timeout_ms), child.wait()).await
+        {
+            Ok(res) => (Some(res?), false),
+            Err(_elapsed) => {
+                // Best-effort terminate the direct child, then reap it.
+                let _ = child.start_kill();
+                let _ = child.wait().await;
+                (None, true)
+            }
+        }
+    };
+
+    if timed_out {
+        // The direct child is dead, but a grandchild may still hold the pipes
+        // open. Give the drain tasks a short grace period to flush, then abort
+        // so a surviving grandchild can never block our return.
+        let grace = std::time::Duration::from_millis(200);
+        let _ = tokio::time::timeout(grace, async {
+            let _ = stdout_task.await;
+            let _ = stderr_task.await;
+        })
+        .await;
+        stdout_abort.abort();
+        stderr_abort.abort();
+    } else {
+        // Normal exit: the pipes reach EOF, so the drain tasks complete.
+        let _ = stdout_task.await;
+        let _ = stderr_task.await;
+    }
+
+    let stdout = stdout_buf.lock().map(|g| g.clone()).unwrap_or_default();
+    let stderr = stderr_buf.lock().map(|g| g.clone()).unwrap_or_default();
+
+    Ok(ManagedOutput {
+        status,
+        stdout,
+        stderr,
+        timed_out,
+    })
+}
+
+/// Build the standard shell `TargetResult` JSON envelope, adding timeout
+/// metadata and an actionable recovery hint when the command was terminated by
+/// a timeout.
+fn build_shell_target_result(
+    kind: ExecTargetKind,
+    docker: Option<DockerMeta>,
+    managed: ManagedOutput,
+    timeout_ms: u64,
+    max_tool_output_bytes: usize,
+) -> TargetResult {
+    let stdout_raw = String::from_utf8_lossy(&managed.stdout).to_string();
+    let stderr_raw = String::from_utf8_lossy(&managed.stderr).to_string();
+    let (stdout, stdout_truncated) = truncate_utf8_to_bytes(&stdout_raw, max_tool_output_bytes);
+    let (stderr, stderr_truncated) = truncate_utf8_to_bytes(&stderr_raw, max_tool_output_bytes);
+    let status_code = managed.status.and_then(|s| s.code());
+    let ok = !managed.timed_out && managed.status.map(|s| s.success()).unwrap_or(false);
+    let mut content = json!({
+        "status": status_code,
+        "stdout": stdout,
+        "stderr": stderr,
+        "stdout_truncated": stdout_truncated,
+        "stderr_truncated": stderr_truncated,
+        "max_tool_output_bytes": max_tool_output_bytes
+    });
+    if managed.timed_out {
+        if let Some(obj) = content.as_object_mut() {
+            obj.insert("timed_out".to_string(), json!(true));
+            obj.insert("timeout_ms".to_string(), json!(timeout_ms));
+            obj.insert(
+                "hint".to_string(),
+                json!(format!(
+                    "Shell command exceeded the {timeout_ms} ms timeout and was terminated before it finished. Re-run with a larger timeout_ms, make the command non-interactive, or narrow its scope."
+                )),
+            );
+        }
+    }
+    TargetResult {
+        ok,
+        content: content.to_string(),
+        truncated: stdout_truncated || stderr_truncated,
+        bytes: Some((managed.stdout.len() + managed.stderr.len()) as u64),
+        exit_code: status_code,
+        stderr_truncated: Some(stderr_truncated),
+        stdout_truncated: Some(stdout_truncated),
+        execution_target: kind,
+        docker,
+    }
+}
+
 fn truncate_utf8_to_bytes(input: &str, max_bytes: usize) -> (String, bool) {
     if max_bytes == 0 {
         return (input.to_string(), false);
@@ -1070,10 +1230,96 @@ mod tests {
                 args: vec!["hi".to_string()],
                 cwd: Some("../".to_string()),
                 max_tool_output_bytes: 200_000,
+                timeout_ms: 0,
             })
             .await;
         assert!(!out.ok);
         assert!(out.content.contains("must stay within workdir"));
+    }
+
+    fn fast_echo_shell_req() -> ShellReq {
+        if cfg!(windows) {
+            ShellReq {
+                workdir: PathBuf::from("."),
+                cmd: "cmd".to_string(),
+                args: vec!["/C".to_string(), "echo ok".to_string()],
+                cwd: None,
+                max_tool_output_bytes: 200_000,
+                timeout_ms: 0,
+            }
+        } else {
+            ShellReq {
+                workdir: PathBuf::from("."),
+                cmd: "sh".to_string(),
+                args: vec!["-c".to_string(), "echo ok".to_string()],
+                cwd: None,
+                max_tool_output_bytes: 200_000,
+                timeout_ms: 0,
+            }
+        }
+    }
+
+    fn slow_sleep_shell_req(timeout_ms: u64) -> ShellReq {
+        if cfg!(windows) {
+            ShellReq {
+                workdir: PathBuf::from("."),
+                cmd: "cmd".to_string(),
+                args: vec!["/C".to_string(), "ping -n 6 127.0.0.1 >NUL".to_string()],
+                cwd: None,
+                max_tool_output_bytes: 200_000,
+                timeout_ms,
+            }
+        } else {
+            ShellReq {
+                workdir: PathBuf::from("."),
+                cmd: "sh".to_string(),
+                args: vec!["-c".to_string(), "sleep 5".to_string()],
+                cwd: None,
+                max_tool_output_bytes: 200_000,
+                timeout_ms,
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn host_shell_under_timeout_succeeds_normally() {
+        let mut req = fast_echo_shell_req();
+        req.timeout_ms = 5_000;
+        let out = HostTarget.exec_shell(req).await;
+        assert!(out.ok, "fast command should succeed: {}", out.content);
+        assert!(out.content.contains("ok"));
+        assert!(!out.content.contains("timed_out"));
+    }
+
+    #[tokio::test]
+    async fn host_shell_zero_timeout_is_unbounded_and_back_compatible() {
+        // timeout_ms == 0 preserves historical unbounded behavior; a fast
+        // command still completes normally.
+        let out = HostTarget.exec_shell(fast_echo_shell_req()).await;
+        assert!(out.ok, "command should succeed: {}", out.content);
+        assert!(out.content.contains("ok"));
+        assert!(!out.content.contains("timed_out"));
+    }
+
+    #[tokio::test]
+    async fn host_shell_exceeding_timeout_returns_timeout_failure() {
+        let start = std::time::Instant::now();
+        let out = HostTarget.exec_shell(slow_sleep_shell_req(200)).await;
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed < std::time::Duration::from_secs(2),
+            "timed-out command should return promptly, took {elapsed:?}"
+        );
+        assert!(!out.ok, "timed-out command must not report success");
+        let parsed: serde_json::Value =
+            serde_json::from_str(&out.content).expect("timeout content is JSON");
+        assert_eq!(parsed["timed_out"], serde_json::json!(true));
+        assert_eq!(parsed["timeout_ms"], serde_json::json!(200));
+        let hint = parsed["hint"].as_str().unwrap_or_default();
+        assert!(
+            hint.contains("timeout_ms"),
+            "timeout result should include an actionable hint, got: {hint}"
+        );
     }
 
     #[test]

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -127,6 +127,7 @@ pub enum ToolErrorCode {
     ShellExecNotFound,
     ShellExecOsError,
     ShellExecNonZeroExit,
+    ShellExecTimeout,
 }
 
 impl ToolErrorCode {
@@ -145,6 +146,7 @@ impl ToolErrorCode {
             Self::ShellExecNotFound => "shell_exec_not_found",
             Self::ShellExecOsError => "shell_exec_os_error",
             Self::ShellExecNonZeroExit => "shell_exec_non_zero_exit",
+            Self::ShellExecTimeout => "shell_exec_timeout",
         }
     }
 }

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -128,6 +128,7 @@ pub enum ToolErrorCode {
     ShellExecOsError,
     ShellExecNonZeroExit,
     ShellExecTimeout,
+    ShellExecTimeoutUnsupported,
 }
 
 impl ToolErrorCode {
@@ -147,6 +148,7 @@ impl ToolErrorCode {
             Self::ShellExecOsError => "shell_exec_os_error",
             Self::ShellExecNonZeroExit => "shell_exec_non_zero_exit",
             Self::ShellExecTimeout => "shell_exec_timeout",
+            Self::ShellExecTimeoutUnsupported => "shell_exec_timeout_unsupported",
         }
     }
 }

--- a/src/tools/catalog.rs
+++ b/src/tools/catalog.rs
@@ -68,13 +68,14 @@ pub fn builtin_tools_enabled(enable_write_tools: bool, enable_shell_tool: bool) 
     if enable_shell_tool {
         tools.push(ToolDef {
             name: "shell".to_string(),
-            description: "Run a shell command with optional args and cwd.".to_string(),
+            description: "Run a shell command with optional args, cwd, and timeout_ms. timeout_ms bounds the command's wall-clock runtime in milliseconds; omit or use 0 for no timeout.".to_string(),
             parameters: json!({
                 "type":"object",
                 "properties":{
                     "cmd":{"type":"string"},
                     "args":{"type":"array","items":{"type":"string"}},
-                    "cwd":{"type":"string"}
+                    "cwd":{"type":"string"},
+                    "timeout_ms":{"type":"integer","minimum":0}
                 },
                 "required":["cmd"]
             }),

--- a/src/tools/exec_shell.rs
+++ b/src/tools/exec_shell.rs
@@ -39,12 +39,16 @@ pub(super) async fn run_shell(rt: &ToolRuntime, args: &Value) -> ToolExecution {
         .get("cwd")
         .and_then(|v| v.as_str())
         .map(ToString::to_string);
+    // `timeout_ms` is optional; absent or 0 preserves unbounded behavior. The
+    // `as_u64` parse makes negative values unrepresentable.
+    let timeout_ms = args.get("timeout_ms").and_then(|v| v.as_u64()).unwrap_or(0);
     let req = ShellReq {
         workdir: rt.workdir.clone(),
         cmd: cmd.to_string(),
         args: arg_list.clone(),
         cwd: cwd.clone(),
         max_tool_output_bytes: rt.max_tool_output_bytes,
+        timeout_ms,
     };
     let mut out = rt.exec_target.exec_shell(req).await;
     if !out.ok && shell_spawn_not_found(&out.content) {
@@ -59,6 +63,7 @@ pub(super) async fn run_shell(rt: &ToolRuntime, args: &Value) -> ToolExecution {
                     args: repair_args,
                     cwd,
                     max_tool_output_bytes: rt.max_tool_output_bytes,
+                    timeout_ms,
                 })
                 .await;
             out = annotate_shell_repair(repaired, repair_strategy);
@@ -71,6 +76,9 @@ pub(super) fn classify_shell_target_error(
     content: &str,
     exit_code: Option<i32>,
 ) -> ToolErrorDetail {
+    if let Some(detail) = timeout_error_from_content(content) {
+        return detail;
+    }
     let lower = content.to_ascii_lowercase();
     let spawn_failed = lower.contains("shell execution failed:");
     let not_found = lower.contains("program not found")
@@ -107,6 +115,25 @@ pub(super) fn classify_shell_target_error(
         minimal_example: minimal_builtin_example("shell"),
         available_tools: None,
     }
+}
+
+fn timeout_error_from_content(content: &str) -> Option<ToolErrorDetail> {
+    let parsed = serde_json::from_str::<Value>(content).ok()?;
+    if parsed.get("timed_out").and_then(|v| v.as_bool()) != Some(true) {
+        return None;
+    }
+    let message = match parsed.get("timeout_ms").and_then(|v| v.as_u64()) {
+        Some(ms) => format!("Shell command exceeded the {ms} ms timeout and was terminated."),
+        None => "Shell command exceeded its timeout and was terminated.".to_string(),
+    };
+    Some(ToolErrorDetail {
+        code: ToolErrorCode::ShellExecTimeout,
+        message,
+        expected_schema: None,
+        received_args: None,
+        minimal_example: minimal_builtin_example("shell"),
+        available_tools: None,
+    })
 }
 
 fn shell_status_code_from_content(content: &str) -> Option<i32> {

--- a/src/tools/exec_shell.rs
+++ b/src/tools/exec_shell.rs
@@ -76,6 +76,9 @@ pub(super) fn classify_shell_target_error(
     content: &str,
     exit_code: Option<i32>,
 ) -> ToolErrorDetail {
+    if let Some(detail) = timeout_unsupported_error_from_content(content) {
+        return detail;
+    }
     if let Some(detail) = timeout_error_from_content(content) {
         return detail;
     }
@@ -115,6 +118,27 @@ pub(super) fn classify_shell_target_error(
         minimal_example: minimal_builtin_example("shell"),
         available_tools: None,
     }
+}
+
+fn timeout_unsupported_error_from_content(content: &str) -> Option<ToolErrorDetail> {
+    let parsed = serde_json::from_str::<Value>(content).ok()?;
+    if parsed.get("error").and_then(|v| v.as_str()) != Some("timeout_unsupported") {
+        return None;
+    }
+    let target = parsed
+        .get("execution_target")
+        .and_then(|v| v.as_str())
+        .unwrap_or("this");
+    Some(ToolErrorDetail {
+        code: ToolErrorCode::ShellExecTimeoutUnsupported,
+        message: format!(
+            "timeout_ms is not supported on the {target} execution target. Re-run on the host target or omit timeout_ms."
+        ),
+        expected_schema: None,
+        received_args: None,
+        minimal_example: minimal_builtin_example("shell"),
+        available_tools: None,
+    })
 }
 
 fn timeout_error_from_content(content: &str) -> Option<ToolErrorDetail> {

--- a/src/tools/schema.rs
+++ b/src/tools/schema.rs
@@ -34,7 +34,8 @@ pub fn compact_builtin_schema(tool_name: &str) -> Option<Value> {
             "properties":{
                 "cmd":{"type":"string"},
                 "args":{"type":"array","items":{"type":"string"}},
-                "cwd":{"type":"string"}
+                "cwd":{"type":"string"},
+                "timeout_ms":{"type":"integer","minimum":0}
             }
         })),
         "write_file" => Some(json!({
@@ -184,6 +185,11 @@ pub fn validate_builtin_tool_args(
             if let Some(v) = obj.get("cwd") {
                 if v.as_str().is_none() {
                     return Err("cwd must be a string".to_string());
+                }
+            }
+            if let Some(v) = obj.get("timeout_ms") {
+                if v.as_u64().is_none() {
+                    return Err("timeout_ms must be a non-negative integer".to_string());
                 }
             }
         }

--- a/src/tools/tests.rs
+++ b/src/tools/tests.rs
@@ -771,10 +771,15 @@ async fn shell_auto_repair_wraps_windows_builtin() {
         exec_target_kind: ExecTargetKind::Host,
         exec_target: std::sync::Arc::new(HostTarget),
     };
+    // Use `ver` rather than `echo`: both are cmd builtins, but `echo` is often
+    // shadowed by an MSYS/Git `echo.exe` on PATH, which lets the direct spawn
+    // succeed and bypasses the repair path. `ver` has no standalone executable
+    // counterpart, so the initial spawn deterministically fails regardless of
+    // host PATH contents, forcing the windows_cmd_c auto-repair.
     let tc = ToolCall {
         id: "tc_shell_auto_repair_win".to_string(),
         name: "shell".to_string(),
-        arguments: json!({"cmd":"echo","args":["hi-manual-test"]}),
+        arguments: json!({"cmd":"ver"}),
     };
     let msg = execute_tool(&rt, &tc).await;
     let envelope: Value = serde_json::from_str(&msg.content.expect("content")).expect("json");
@@ -788,7 +793,11 @@ async fn shell_auto_repair_wraps_windows_builtin() {
         .get("stdout")
         .and_then(|v| v.as_str())
         .unwrap_or_default();
-    assert!(stdout.contains("hi-manual-test"));
+    // `cmd /c ver` prints a line like "Microsoft Windows [Version 10.0.x]".
+    assert!(
+        stdout.to_ascii_lowercase().contains("windows"),
+        "expected `ver` output to mention Windows, got: {stdout}"
+    );
     assert_eq!(
         inner.get("repair_attempted").and_then(|v| v.as_bool()),
         Some(true)


### PR DESCRIPTION
## Summary

Adds bounded shell command execution for LocalAgent so shell tool calls can fail safely instead of hanging indefinitely.

This PR adds optional `timeout_ms` support to shell execution, returns a structured timeout failure with partial output, and uses managed child execution with best-effort direct-child cleanup.

## What changed

* Added `ShellReq.timeout_ms`
* Advertised optional `timeout_ms` in the shell tool schema
* Replaced `command.output().await` with managed child execution
* Added timeout handling via `tokio::time::timeout`
* Added direct-child cleanup via `kill_on_drop` / `start_kill`
* Added structured timeout responses with:

  * `timed_out: true`
  * `timeout_ms`
  * partial stdout/stderr
  * actionable hint
* Added `ToolErrorCode::ShellExecTimeout`
* Added `ToolErrorCode::ShellExecTimeoutUnsupported`
* Rejects `timeout_ms > 0` on DockerTarget with a structured unsupported-target error instead of silently ignoring it
* Stabilized the Windows shell auto-repair test by using `ver` instead of `echo`

## Why

Previously, `HostTarget::exec_shell` used `command.output().await` with no timeout or managed lifecycle. A hanging command could block the agent indefinitely, and cancelling a TUI turn could orphan the child process.

This PR fixes the highest-priority harness reliability issue from the opencode capability audit.

## Validation

* `cargo fmt --check`
* `cargo clippy --all-targets -- -D warnings`
* `cargo test --lib target::`
* `cargo test --lib tools::`
* `cargo test --test tool_call_accuracy_ci`
* `cargo test --lib repro`
* `cargo test --test artifact_golden`
* `python scripts/ci_release_readiness.py`

All required validation passed.

## Known limitations

* Process-tree cleanup is best-effort direct-child cleanup only.
* Grandchildren spawned through `sh -c`, `cmd /C`, or similar wrappers may continue until they exit.
* DockerTarget does not yet enforce shell timeouts. It now rejects `timeout_ms > 0` clearly instead of ignoring it.
* Live output streaming is not included in this PR.

## Follow-ups

* Robust Unix process-group cleanup and Windows job-object cleanup
* Real Docker shell timeout enforcement
* Default shell timeout policy for autonomous runs
* Live shell output streaming / TUI tail events
